### PR TITLE
Updating the Config File Behaviour

### DIFF
--- a/pyccoon/pyccoon.py
+++ b/pyccoon/pyccoon.py
@@ -106,7 +106,7 @@ class Pyccoon:
 
     def init_config(self):
         """ Try to get `.pyccoon` config file or use the default values """
-        config_file = os.path.join(self.sourcedir, self.config_file)
+        config_file = os.path.join(os.getcwd(), self.config_file)
         if os.path.exists(config_file):
             self.log('Using config {0:s}'.format(config_file))
             with open(config_file, 'rb') as f:


### PR DESCRIPTION
Pyccoon searched for the config in relation to the given source
directory, the default being `.pycoon`. Now, the search is done in
relation to the current working directory. The `-c` flag also respects
this change.

---

All the tests ran for me:

```
test_something (tests.test_pyccoon.TestPyccoon) ... ok
test (tests.tests.Crossref) ... ok
test (tests.tests.DummyFileTest)
 DummyFileTest: Check that files exist. This method should be overridden  ... ok
test (tests.tests.FileTest) ... ok
test (tests.tests.PyDocSubstitutions) ... ok
test (tests.tests.PythonLanguage) ... ok
test (tests.tests.RubyLanguage) ... ok
test (tests.tests.TodoSubstitutions) ... ok

----------------------------------------------------------------------
Ran 8 tests in 0.326s

OK
```

Let me know if I've missed anything!
